### PR TITLE
Updates for 2024

### DIFF
--- a/lectures/classes/README.md
+++ b/lectures/classes/README.md
@@ -249,7 +249,7 @@ Note that an object in C++ may not be an object in the OOP sense!
 ---
 # Member functions
 
-Typically these are declared in the class definition...
+Typically these are *declared* in the class definition...
 
 ```C++
 // complex.hpp
@@ -269,7 +269,7 @@ If anyone asks, discussion of const is coming up!
 ---
 # Member functions
 
-... and defined out of line
+... and *defined* out of line
 
 ```C++
 // complex.cpp

--- a/lectures/cpp-intro/README.md
+++ b/lectures/cpp-intro/README.md
@@ -126,7 +126,7 @@ Every three years there is a new update to the International Standard
 Latest one, C++20, still not fully implemented by an compiler. Major
 new features are ranges, coroutines, concepts, and modules
 
-C++23 is still in draft (N4944). Major features likely to include
+C++23 is still in draft (N4950). Major features likely to include
 networking, string formatting, executors, and consolidation of new
 C++20 features
 
@@ -253,12 +253,12 @@ __ARCHER2__: You have log in details.
 
 Once connected you need to load the up-to-date compilers:
 ```
-module load gcc/10.2.0
+module load gcc/11.2.0
 ```
 
 ???
 
-There are later versions of GCC on ARCHER2 but 10.2.0 is the default version
+There are later versions of GCC on ARCHER2 but 11.2.0 is the default version
 
 ---
 # Getting the source code
@@ -408,7 +408,7 @@ Go look them up on CPP Reference as you need to
 
 # Strings
 
-The standard library has a class* called `string` that holds a string
+The standard library has a class called `string` that holds a string
 of text characters.
 
 You have to `#include <string>` to use it which includes the "header


### PR DESCRIPTION
Minor updates for 2024 - default version of GCC on ARCHER2 and C++23 draft version