### PR TITLE
Update remark theme

### DIFF
--- a/lectures/algorithms-lambdas-traits/index.html
+++ b/lectures/algorithms-lambdas-traits/index.html
@@ -1,31 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>C++ for numerical computing part 2</title>
+<title>Algorithms, lambdas, traits</title>
 <meta charset="utf-8">
 
 <script src="https://remarkjs.com/downloads/remark-latest.min.js"></script>
-<script src="https://epcced.github.io/remark_theme/latest.js"></script>
-<script src="../template/cpptheme.js"></script>
+<script type="module" src="../template/cpptheme.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML&delayStartupUntil=configured" type="text/javascript"></script>
+<script defer src="../template/mathjax-setup.js"></script>
 
 </head>
-
-<body>
-
-<script>
-epcc.install();
-cpptheme.install();
-var slideshow = remark.create({sourceUrl: 'README.md'});
-      // Setup MathJax
-      MathJax.Hub.Config({
-          tex2jax: {
-          skipTags: ['script', 'noscript', 'style', 'textarea', 'pre']
-          }
-      });
-
-      MathJax.Hub.Configured();
-</script>
-
-</body>
 </html>

--- a/lectures/classes/index.html
+++ b/lectures/classes/index.html
@@ -5,27 +5,9 @@
 <meta charset="utf-8">
 
 <script src="https://remarkjs.com/downloads/remark-latest.min.js"></script>
-<script src="https://epcced.github.io/remark_theme/latest.js"></script>
-<script src="../template/cpptheme.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_HTML&delayStartupUntil=configured" type="text/javascript"></script>
+<script type="module" src="../template/cpptheme.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML&delayStartupUntil=configured" type="text/javascript"></script>
+<script defer src="../template/mathjax-setup.js"></script>
 
 </head>
-
-<body>
-
-<script>
-epcc.install();
-cpptheme.install();
-var slideshow = remark.create({sourceUrl: 'README.md'});
-// Setup MathJax
-MathJax.Hub.Config({
-  tex2jax: {
-    skipTags: ['script', 'noscript', 'style', 'textarea', 'pre']
-  }
-});
-
-MathJax.Hub.Configured();
-</script>
-
-</body>
 </html>

--- a/lectures/cpp-intro/index.html
+++ b/lectures/cpp-intro/index.html
@@ -5,18 +5,7 @@
 <meta charset="utf-8">
 
 <script src="https://remarkjs.com/downloads/remark-latest.min.js"></script>
-<script src="https://epcced.github.io/remark_theme/latest.js"></script>
-<script src="../template/cpptheme.js"></script>
+<script type="module" src="../template/cpptheme.js"></script>
 
 </head>
-
-<body>
-
-<script>
-epcc.install();
-cpptheme.install();
-var slideshow = remark.create({sourceUrl: 'README.md'});
-</script>
-
-</body>
 </html>

--- a/lectures/eigen/index.html
+++ b/lectures/eigen/index.html
@@ -1,30 +1,17 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>A brief introduction to C++</title>
+<title>Linear Algebra for C++</title>
 <meta charset="utf-8">
 
 <script src="https://remarkjs.com/downloads/remark-latest.min.js"></script>
-<script src="https://epcced.github.io/remark_theme/latest.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_HTML&delayStartupUntil=configured" type="text/javascript"></script>
-<script src="../template/cpptheme.js"></script>
+
+<!--URL Encoded Footer = "&copy; Joseph Lee, Rupert Nash (EPCC), Chris Richardson (University of Cambridge), CC-BY"-->
+<script type="module" src="../template/cpptheme.js?footer=%26copy%3B%20Joseph%20Lee%2C%20Rupert%20Nash%20%28EPCC%29%2C%20Chris%20Richardson%20%28University%20of%20Cambridge%29%2C%20CC-BY"></script>
+  
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML&delayStartupUntil=configured" type="text/javascript"></script>
+<script defer src="../template/mathjax-setup.js"></script>
 
 </head>
 
-<body>
-
-<script>
-epcc.footer_text = "&copy; Joseph Lee, Rupert Nash (EPCC), Chris Richardson (University of Cambridge), CC-BY";
-epcc.install();
-cpptheme.install();
-var slideshow = remark.create({sourceUrl: 'README.md'});
-MathJax.Hub.Config({
-          tex2jax: {
-          skipTags: ['script', 'noscript', 'style', 'textarea', 'pre']
-          }
-      });
-MathJax.Hub.Configured();
-</script>
-
-</body>
 </html>

--- a/lectures/loops-containers/index.html
+++ b/lectures/loops-containers/index.html
@@ -1,22 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>C++ for numerical computing</title>
+<title>Containers, loops, and iterators</title>
 <meta charset="utf-8">
 
 <script src="https://remarkjs.com/downloads/remark-latest.min.js"></script>
-<script src="https://epcced.github.io/remark_theme/latest.js"></script>
-<script src="../template/cpptheme.js"></script>
+<script type="module" src="../template/cpptheme.js"></script>
 
 </head>
-
-<body>
-
-<script>
-epcc.install();
-cpptheme.install();
-var slideshow = remark.create({sourceUrl: 'README.md'});
-</script>
-
-</body>
 </html>

--- a/lectures/resources/index.html
+++ b/lectures/resources/index.html
@@ -1,22 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>A brief introduction to C++</title>
+<title>Resource Management</title>
 <meta charset="utf-8">
 
 <script src="https://remarkjs.com/downloads/remark-latest.min.js"></script>
-<script src="https://epcced.github.io/remark_theme/latest.js"></script>
-<script src="../template/cpptheme.js"></script>
+<script type="module" src="../template/cpptheme.js"></script>
 
 </head>
-
-<body>
-
-<script>
-epcc.install();
-cpptheme.install();
-var slideshow = remark.create({sourceUrl: 'README.md'});
-</script>
-
-</body>
 </html>

--- a/lectures/template/cpptheme.js
+++ b/lectures/template/cpptheme.js
@@ -1,10 +1,16 @@
+import {epcc, Theme} from "https://EPCCed.github.io/remark_theme/latest.js";
 
 epcc.footer_text = "&copy; Rupert Nash, The University of Edinburgh, CC-BY";
-cpptheme = new Theme(
-    (str => str.substring(0, str.lastIndexOf("/")))(document.currentScript.src),
+var cpptheme = new Theme(
+    (str => str.substring(0, str.lastIndexOf("/")))(import.meta.url),
     '$BASEURL/style.css',
     {
-	thumb: function () {
-	    return '.thumb[\n.thumbtxt[\n' + this +'\n]\n]';
-	}
-    });
+        thumb: function () {
+            return '.thumb[\n.thumbtxt[\n' + this +'\n]\n]';
+        }
+    }
+);
+
+epcc.install();
+cpptheme.install();
+globalThis.slideshow = remark.create({sourceUrl: 'README.md'});

--- a/lectures/template/cpptheme.js
+++ b/lectures/template/cpptheme.js
@@ -1,6 +1,12 @@
 import {epcc, Theme} from "https://EPCCed.github.io/remark_theme/latest.js";
 
-epcc.footer_text = "&copy; Rupert Nash, The University of Edinburgh, CC-BY";
+var footer = new URL(import.meta.url).searchParams.get("footer");
+
+if (!footer) {
+    footer = "&copy; Rupert Nash, The University of Edinburgh, CC-BY";
+}
+epcc.footer_text = footer;
+
 var cpptheme = new Theme(
     (str => str.substring(0, str.lastIndexOf("/")))(import.meta.url),
     '$BASEURL/style.css',

--- a/lectures/template/mathjax-setup.js
+++ b/lectures/template/mathjax-setup.js
@@ -1,0 +1,8 @@
+// Setup MathJax
+MathJax.Hub.Config({
+    tex2jax: {
+    skipTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+    }
+});
+
+MathJax.Hub.Configured();

--- a/lectures/templates/index.html
+++ b/lectures/templates/index.html
@@ -5,18 +5,7 @@
 <meta charset="utf-8">
 
 <script src="https://remarkjs.com/downloads/remark-latest.min.js"></script>
-<script src="https://epcced.github.io/remark_theme/latest.js"></script>
-<script src="../template/cpptheme.js"></script>
+<script type="module" src="../template/cpptheme.js"></script>
 
 </head>
-
-<body>
-
-<script>
-epcc.install();
-cpptheme.install();
-var slideshow = remark.create({sourceUrl: 'README.md'});
-</script>
-
-</body>
 </html>

--- a/lectures/threads-1/index.html
+++ b/lectures/threads-1/index.html
@@ -5,19 +5,9 @@
 <meta charset="utf-8">
 
 <script src="https://remarkjs.com/downloads/remark-latest.min.js"></script>
-<script src="https://epcced.github.io/remark_theme/latest.js"></script>
-<script src="../template/cpptheme.js"></script>
+
+<!--URL Encoded Footer = "&copy; EPCC, The University of Edinburgh, CC-BY-NC-SA 4.0"-->
+<script type="module" src="../template/cpptheme.js?footer=%26copy%3B%20EPCC%2C%20The%20University%20of%20Edinburgh%2C%20CC-BY-NC-SA%204.0"></script>
+
 </head>
-
-<body>
-
-<script>
-epcc.footer_text = "&copy; EPCC, The University of Edinburgh, CC-BY-NC-SA 4.0";
-epcc.install();
-cpptheme.install();
-
-var slideshow = remark.create({sourceUrl: 'README.md'});
-</script>
-
-</body>
 </html>

--- a/lectures/threads-2/index.html
+++ b/lectures/threads-2/index.html
@@ -5,19 +5,9 @@
 <meta charset="utf-8">
 
 <script src="https://remarkjs.com/downloads/remark-latest.min.js"></script>
-<script src="https://epcced.github.io/remark_theme/latest.js"></script>
-<script src="../template/cpptheme.js"></script>
+
+<!--URL Encoded Footer = "&copy; EPCC, The University of Edinburgh, CC-BY-NC-SA 4.0"-->
+<script type="module" src="../template/cpptheme.js?footer=%26copy%3B%20EPCC%2C%20The%20University%20of%20Edinburgh%2C%20CC-BY-NC-SA%204.0"></script>
+
 </head>
-
-<body>
-
-<script>
-epcc.footer_text = "&copy; EPCC, The University of Edinburgh, CC-BY-NC-SA 4.0";
-epcc.install();
-cpptheme.install();
-
-var slideshow = remark.create({sourceUrl: 'README.md'});
-</script>
-
-</body>
 </html>


### PR DESCRIPTION
This will modify the slide decks to use the updated EPCC remark theme. Additionally, scripts being used across chapters have now been consolidated into either `cpptheme.js` or `mathjax-setup.js`.

Note: The EPCC remark theme is now deployed as a specific version. So if further breaking changes happened, we could lock into using an older version of the theme rather than the latest version. E.g. by importing from "https://epcced.github.io/remark_theme/1/1/2/epcc.js" and "https://epcced.github.io/remark_theme/1/1/2/theme.js" in `cpptheme.js`.